### PR TITLE
enforcing SSL - response to #1

### DIFF
--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -28,6 +28,7 @@ module BigCommerce
 			uri = URI.parse(url)
 
 			http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
 
 			request = case method
 				when :get    then Net::HTTP::Get.new(uri.request_uri)


### PR DESCRIPTION
https://github.com/bigcommerce/bigcommerce-api-ruby/issues/1

I was having the same error response as this guy (although I have api access).

Then I examined the request properties and saw that SSL wasn't being enforced

So I had a choice to go with something that pins the SSL responsibility on the user giving an "https://" :store_url
```http.use_ssl = (uri.scheme == "https")

```
however, when forcing SSL, we minimize likelihood of user error at the expense of some flexibility.
(but I doubt you'll ever not use SSL for api requests anyway)
```
