### PR TITLE
Installation / Gemspec Fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     metaclass (0.0.1)
     mocha (0.10.5)
       metaclass (~> 0.0.1)
+    rake (0.9.2.2)
 
 PLATFORMS
   ruby
@@ -20,3 +21,4 @@ DEPENDENCIES
   bigcommerce!
   fakeweb
   mocha
+  rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-#require 'lib/bigcommerce'
-require 'rake/testtask'
+require 'rubygems'
 require 'bundler'
+require 'rake/testtask'
 Bundler::GemHelper.install_tasks
 
 Rake::TestTask.new(:test) do |t|

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -1,5 +1,5 @@
-$:.push File.expand_path("../lib", __FILE__)
-require "bigcommerce"
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/bigcommerce/version', __FILE__)
 
 Gem::Specification.new do |s|
   s.name     = "bigcommerce"
@@ -11,8 +11,9 @@ Gem::Specification.new do |s|
   s.description = "Enables Ruby applications to communicate with the BigCommerce API V2 (currently in beta trial)."
   s.has_rdoc = false
   s.authors  = ["BigCommerce"]
-  s.files = ["LICENSE", "Rakefile", "README.md", "bigcommerce.gemspec"] + Dir['**/*.rb'] + Dir['**/*.crt']
+  s.files = ["LICENSE", "Rakefile", "README.md", "bigcommerce.gemspec"] + Dir['./**/*.rb'] + Dir['./**/*.crt']
   s.add_dependency('json')
+  s.add_development_dependency("rake")
   s.add_development_dependency("fakeweb")
   s.add_development_dependency("mocha")
 

--- a/lib/bigcommerce.rb
+++ b/lib/bigcommerce.rb
@@ -1,13 +1,9 @@
+require "rubygems"
 require "cgi"
 require "uri"
 require "net/https"
-
-require "rubygems"
 require "json"
 
-require File.join(File.dirname(__FILE__), 'bigcommerce', 'api')
-require File.join(File.dirname(__FILE__), 'bigcommerce', 'connection')
-
-module BigCommerce
-  VERSION = "0.0.5"
-end
+require File.expand_path('../bigcommerce/version', __FILE__)
+require File.expand_path('../bigcommerce/api', __FILE__)
+require File.expand_path('../bigcommerce/connection', __FILE__)

--- a/lib/bigcommerce/version.rb
+++ b/lib/bigcommerce/version.rb
@@ -1,0 +1,3 @@
+module BigCommerce
+  VERSION = "0.0.5"
+end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -9,7 +9,6 @@ class ApiTest < Test::Unit::TestCase
 
     @rfc2822_datetime = "Tue, 13 Mar 2012 12:45:26 +0000"
     @rfc2822_date = "Mon, 12 Mar 2012 00:00:00 +0000"
-
   end
 
   def teardown
@@ -48,7 +47,7 @@ class ApiTest < Test::Unit::TestCase
 
   def test_get_orders_with_pagination_and_limit
     @api.connection.expects(:get).with("/orders", {:limit=>10, :page=>2})
-     @api.get_orders(:limit => 10, :page => 2)
+    @api.get_orders(:limit => 10, :page => 2)
   end
 
   def test_get_orders_by_date_with_pagination
@@ -57,7 +56,6 @@ class ApiTest < Test::Unit::TestCase
 
     # Test DateTime
     @api.get_orders_by_date(DateTime.parse('2012-03-13 12:45:26 GMT'), :page => 2)
-
   end
 
   def test_get_orders_by_date_with_date_time
@@ -66,7 +64,6 @@ class ApiTest < Test::Unit::TestCase
 
     # Test DateTime
     @api.get_orders_by_date(DateTime.parse('2012-03-13 12:45:26 GMT'))
-
   end
 
   def test_get_orders_by_date_with_date
@@ -75,7 +72,6 @@ class ApiTest < Test::Unit::TestCase
 
     # Test Date
     @api.get_orders_by_date(Date.parse("2012-03-12"))
-
   end
 
   def test_get_orders_by_date_with_string
@@ -86,9 +82,6 @@ class ApiTest < Test::Unit::TestCase
     # Test String
     @api.get_orders_by_date('2012-03-13 12:45:26 GMT')
     @api.get_orders_by_date('2012-03-12')
-
-
   end
-
 
 end


### PR DESCRIPTION
- Removes $LOAD_PATH munging
- Adds Rake as development dependency so as not to relay on a globally-installed version.
- Breaks out BigCommerce::VERSION to a separate file to avoid a dependency hell catch-22 when installing for the first time.
