### PR TITLE
Add method for returning product count

### DIFF
--- a/lib/bigcommerce/api.rb
+++ b/lib/bigcommerce/api.rb
@@ -44,6 +44,10 @@ module Bigcommerce
       @connection.get '/products'
     end
 
+    def get_products_count
+      @connection.get '/products/count/'
+    end
+
     def get_brands
       @connection.get '/brands'
     end


### PR DESCRIPTION
We currently have a count method for all resources except products and categories. This pull request adds a method for products that does GET on '/products/count/' to return the total product count.
