### PR TITLE
Strip segments off configured URLs

### DIFF
--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -2,11 +2,15 @@ module Bigcommerce
   class Connection
 
     def initialize(configuration)
-      @configuration = configuration
+      @configuration = {}
+      configuration.each do |key, val|
+        send(key.to_s + "=", val)
+      end
     end
 
     def store_url=(store_url)
-      @configuration[:store_url] = store_url
+      url = URI.parse(store_url)
+      @configuration[:store_url] = url.scheme + "://" + url.host
     end
 
     def username=(username)


### PR DESCRIPTION
When URLs are provided with additional `/` and segment paths, strip the configured URL to its base path by default.

This avoids confusion between API docs and the control panel itself, which provides the full URL with `/api/v2` to cut/paste.
