### PR TITLE
Get and create images for a specific product

### DIFF
--- a/lib/bigcommerce/api.rb
+++ b/lib/bigcommerce/api.rb
@@ -281,6 +281,14 @@ module Bigcommerce
       @connection.get("/products/#{product_id}/customfields/#{custom_field_id}", {})
     end
 
+    def get_product_images(product_id, options={})
+      @connection.get("/products/#{product_id}/images", options)
+    end
+    
+    def create_product_images(product_id, options={})
+      @connection.post("/products/#{product_id}/images", options)
+    end
+
     def get_products_images(options={})
       @connection.get("/products/images", options)
     end


### PR DESCRIPTION
Added 2 methods to get and create images for a specific product. 

```
GET /products/id/images.json
POST /products/id/images.json
```

The problem is the naming of the method "get_product_images" and "create_product_images" aren't quite right because all product resources are named plural. But I don't really know how to name them.

This should be added for every product specific resource like videos or discount rules.
