### PR TITLE
Corrects RubyGem badge name and URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Bigcommerce API V2 - Ruby Client
 ================================
 
-[![Gem Version](https://badge.fury.io/rb/bigcommerce-api-ruby.png)](https://rubygems.org/gems/bigcommerce-api-ruby)
+[![Gem Version](https://badge.fury.io/rb/bigcommerce.png)](https://rubygems.org/gems/bigcommerce)
 [![Build Status](https://travis-ci.org/bigcommerce/bigcommerce-api-ruby.png?branch=master)](https://travis-ci.org/bigcommerce/bigcommerce-api-ruby)
 [![Dependency Status](https://gemnasium.com/bigcommerce/bigcommerce-api-ruby.png?travis)](https://gemnasium.com/bigcommerce/bigcommerce-api-ruby)
 [![Code Climate](https://codeclimate.com/github/bigcommerce/bigcommerce-api-ruby.png)](https://codeclimate.com/github/bigcommerce/bigcommerce-api-ruby)


### PR DESCRIPTION
I provided an incorrect URL for the RubyGems badge and hyperlink in #54. :scream_cat: 

This change fixes that egregious error.
