### PR TITLE
Reinstate get_products_count method

### DIFF
--- a/lib/bigcommerce/api.rb
+++ b/lib/bigcommerce/api.rb
@@ -70,7 +70,7 @@ module Bigcommerce
     end
 
     def get_categories_count
-      @connection.get '/categories/count/'
+      @connection.get '/categories/count'
     end
 
     def get_category(id)


### PR DESCRIPTION
The get_products_count method was added some time ago and then it looks like the get_products_count method was removed for some reason.

This request is to add it back.
