### PR TITLE
Adds support for MRI Ruby v2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.1.0
   - 2.0.0
   - 1.9.3
   - jruby-19mode


### PR DESCRIPTION
:information_desk_person: Ruby 2.1.0 was released on 25 December 2013 ([release announcement](https://www.ruby-lang.org/en/news/2013/12/25/ruby-2-1-0-is-released/)). This change adds support for this version of MRI Ruby to the Travis CI build plan.