### PR TITLE
Fix method signature for #options_value.

### DIFF
--- a/lib/bigcommerce/api.rb
+++ b/lib/bigcommerce/api.rb
@@ -162,8 +162,8 @@ module Bigcommerce
        @connection.get("/options/values", options)
     end
 
-    def options_value(id)
-      @connection.get("/options/#{id}/values",{})
+    def options_value(id, options={})
+      @connection.get("/options/#{id}/values", options)
     end
 
     def create_options_values(options_id, options={})

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -32,4 +32,18 @@ describe Bigcommerce::Api do
       api.create_orders_shipments(123, options)
     end
   end
+
+  describe "#get-options-value" do
+    it "should accept an option id parameter" do
+      api.connection.should_receive(:get).once.with("/options/123/values", {})
+      api.options_value(123)
+    end
+
+    it "should accept an option id parameter and an options hash" do
+      options = Hash[*('A'..'Z').to_a.flatten]
+      api.connection.should_receive(:get).once.with("/options/123/values", options)
+      api.options_value(123, options)
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes `api#options_value` method signature to allow for options.

Edit: API docs say "This GET request does not take any parameters" but this is a problem as the default limit is 50 values and as is, the method doesn't allow `limit` or `page` arguments.

`api.get_options_value(50, {:page => 2})` throws an `ArgumentError` (2 for 1)

So, as an example, if you have more than 50 colors for a color option... :shit:
