### PR TITLE
Update Rubinius and MRI versions for compatibility with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.1.0
   - 2.0.0
   - 1.9.3
   - jruby-19mode


### PR DESCRIPTION
:information_desk_person: These changes add a known good version of Rubinius to the build matrix, as [v2.2.4 is currently failing due the build environment](travis-ci/travis-ci#1929), as well as MRI Ruby v2.1.0.
