### PR TITLE
Updates README for to get_orders and get_products

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,16 +115,15 @@ Create Data
 ```
 api.create_products({:name => "Spiderman - The best return",:price => 9.99,:categories => [17],:type =>"physical",:availability => "available", :weight => 1})
 
-api.update_products(31,{:name => "marvel comics spiderman",:sku => "marvel-spidey-1", :inventory_tracking => "simple", :inventory_level => 500})
-
-api.update_orders(101,{:status_id => 12, :is_deleted => true})
-
 ```
+
 Update Data
 
 ```
 api.update_products(31,{:name => "marvel comics spiderman",:sku => "marvel-spidey-1", :inventory_tracking => "simple", :inventory_level => 500})
 
 api.update_optionsets(13,{:name => "Marvel toys"})
+
+api.update_orders(101,{:status_id => 12, :is_deleted => true})
 
 ```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Ping the time method to check that your configuration is working and you
 can connect successfully to the store:
 
 ```
-ping = api.time
+ping = api.get_time
 ```
 
 Usage
@@ -99,15 +99,15 @@ The API object acts as a gateway to all top level resources in the V2 API.
 
 Fetch Data
 ```
-orders = api.orders
-orders = api.orders({:min_id=>100,:max_id=>101})
-orders = api.orders(:is_deleted => true)
+orders = api.get_orders
+orders = api.get_orders({:min_id=>100,:max_id=>101})
+orders = api.get_orders(:is_deleted => true)
 
-products = api.products
-products = api.products(:description=>"iphone", :condition=>"New")
+products = api.get_products
+products = api.get_products(:description=>"iphone", :condition=>"New")
 
-options = api.options
-options = api.options(:type=>"MT")
+options = api.get_options
+options = api.get_options(:type=>"MT")
 ...
 
 ```


### PR DESCRIPTION
I just installed the gem and went through the README. It didn't work as documented and a quick read through the code revealed why.

Changes `api.products` and `api.orders` to `api.get_products` and `api.get_orders`