### PR TITLE
Fixed multiple issues with configuration of Legacy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ api = Bigcommerce::Api.new({
   :store_url => "https://store.mybigcommerce.com",
   :username  => "username",
   :api_key   => "api_key",
-  :ssl_client_cert  =>  OpenSSL::X509::Certificate.new(File.read("cert.pem")),
-  :ssl_client_key   =>  OpenSSL::PKey::RSA.new(File.read("key.pem"), "passphrase, if any"),
-  :ssl_ca_file      =>  "ca_certificate.pem",
+  :ssl_client_cert  =>  "/path/to/cert.pem",
+  :ssl_client_key   =>  { path: "/path/to/key.pem", passphrase: "passphrase, if any" },
+  :ssl_ca_file      =>  "/path/to/ca_certificate.pem",
   :verify_ssl       =>  OpenSSL::SSL::VERIFY_PEER
 })
 ```

--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -42,11 +42,11 @@ module Bigcommerce
       @configuration.ssl_ca_file = path
     end
 
-    def ssl_client_key=(path,passphrase=nil)
-      if passphrase.nil?
-        @configuration.ssl_client_key = OpenSSL::PKey::RSA.new(File.read(path))
+    def ssl_client_key=(options)
+      if options[:passphrase].nil?
+        @configuration.ssl_client_key = OpenSSL::PKey::RSA.new(File.read(options[:path]))
       else
-        @configuration.ssl_client_key = OpenSSL::PKey::RSA.new(File.read(path), passphrase)
+        @configuration.ssl_client_key = OpenSSL::PKey::RSA.new(File.read(options[:path]), options[:passphrase])
       end
     end
 

--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -34,24 +34,24 @@ module Bigcommerce
       @configuration[:api_key] = api_key
     end
 
-    def verify_peer=(verify)
+    def verify_ssl=(verify)
       @configuration[:verify_ssl] = verify
     end
 
     def ssl_ca_file=(path)
-      @configuration.ssl_ca_file = path
+      @configuration[:ssl_ca_file] = path
     end
 
     def ssl_client_key=(options)
       if options[:passphrase].nil?
-        @configuration.ssl_client_key = OpenSSL::PKey::RSA.new(File.read(options[:path]))
+        @configuration[:ssl_client_key] = OpenSSL::PKey::RSA.new(File.read(options[:path]))
       else
-        @configuration.ssl_client_key = OpenSSL::PKey::RSA.new(File.read(options[:path]), options[:passphrase])
+        @configuration[:ssl_client_key] = OpenSSL::PKey::RSA.new(File.read(options[:path]), options[:passphrase])
       end
     end
 
     def ssl_client_cert=(path)
-      @configuration.client_cert = OpenSSL::X509::Certificate.new(File.read(path))
+      @configuration[:ssl_client_cert] = OpenSSL::X509::Certificate.new(File.read(path))
     end
 
     def get(path, options = {}, headers = {})

--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -133,7 +133,7 @@ module Bigcommerce
       if @configuration[:ssl_client_key] && @configuration[:ssl_client_cert] && @configuration[:ssl_ca_file]
         rest_client = RestClient::Resource.new(
             "#{@configuration[:store_url]}/api/v2#{path}.json",
-            :username => @configuration[:username],
+            :user => @configuration[:username],
             :password => @configuration[:api_key],
             :ssl_client_cert => @configuration[:ssl_client_cert],
             :ssl_client_key => @configuration[:ssl_client_key],

--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -125,6 +125,7 @@ module Bigcommerce
       resource_options = {
           :user => @configuration[:username],
           :password => @configuration[:api_key],
+          :verify_ssl => OpenSSL::SSL::VERIFY_NONE,
           :headers => headers
       }
 


### PR DESCRIPTION
I would like to submit the following changes/ fixes in this pull request. Please review and merge the pull request as soon as possible. If you have any questions and concerns about these changes then let me know by replying on this thread.

1. **Error:** `no implicit conversion of OpenSSL::X509::Certificate into String`

    The  `bigcommerce-api-ruby` gem *already takes care* of creating appropriate `OpenSSL::X509::Certificate` and `OpenSSL::PKey::RSA` instances for keys `ssl_client_cert ` and `ssl_client_key ` respectively in `lib/bigcommerce/connection.rb`. It should not be provided again while configuring Legacy API client as it results in above mentioned error.

  **Fixes:**
     Updated `README.md` to reflect the correct usage:
    ```
    require 'bigcommerce'

    api = Bigcommerce::Api.new({
      :store_url => "https://store.mybigcommerce.com",
      :username  => "username",
      :api_key   => "api_key",
      :ssl_client_cert  =>  "/path/to/cert.pem",                ## <<-- Only path should be specified
      :ssl_client_key   =>  { path: "/path/to/key.pem", passphrase: "passphrase, if any" },  ## <<-- path and passphrase should be specified
      :ssl_ca_file      =>  "/path/to/ca_certificate.pem",
      :verify_ssl       =>  OpenSSL::SSL::VERIFY_PEER
   })
   ```
   Also, updated `ssl_client_key=` method in `lib/bigcommerce/connection.rb` so that it accepts an `options` hash with `path` and `passphrase`.

2. **Errors:** `undefined methods client_cert, ssl_client_key, ssl_ca_file and verify_ssl`
    **Fixes:**
    In `lib/bigcommerce/connection.rb`, methods `ssl_ca_file=`, `ssl_client_key=` and `ssl_client_cert=` try to set attributes on `@configuration` which is a `Hash`. This results in undefined methods error in all the three cases. Also, the key name for client certificate is used as `ssl_client_cert` throughout the gem code but in `lib/bigcommerce/connection.rb` it is used as `@configuration.client_cert` , fixed the code to use `@connection[:ssl_client_cert]` instead . Modified code to set the correct key-value pair in `@configuration` Hash is as below:

    ```
    def ssl_ca_file=(path)
      @configuration[:ssl_ca_file] = path   ## <<-- Used @configuration[:ssl_ca_file]  instead of @configuration.ssl_ca_file
    end

    def ssl_client_key=(options)
      if options[:passphrase].nil?
        @configuration[:ssl_client_key] = OpenSSL::PKey::RSA.new(File.read(options[:path]))  ## <<-- Used @configuration[:ssl_client_key]  instead of @configuration.ssl_client_key
      else
        @configuration[:ssl_client_key] = OpenSSL::PKey::RSA.new(File.read(options[:path]), options[:passphrase])  ## <<-- Used @configuration[:ssl_client_key]  instead of @configuration.ssl_client_key
      end
    end

    def ssl_client_cert=(path)
      @configuration[:ssl_client_cert] = OpenSSL::X509::Certificate.new(File.read(path)) ## <<-- Used @configuration[:ssl_client_cert]  instead of @configuration.client_cert
    end

    ```
    Also, while configuring Legacy API with SSL, expected method name is `verify_ssl=` . Corrected the method name from `verify_peer=` to `verify_ssl=` in `lib/bigcommerce/connection.rb`

3. **Error:**`RestClient` uses `:user` as a valid key not `:username`
      **Fixes:**
     Because of this issue the connection was not getting established as `:user` key was not found. Updated `lib/bigcommerce/connection.rb` to set `:user` key instead of `:username`
      
     ```
     if @configuration[:ssl_client_key] && @configuration[:ssl_client_cert] && @configuration[:ssl_ca_file]
        rest_client = RestClient::Resource.new(
            "#{@configuration[:store_url]}/api/v2#{path}.json",
            :user => @configuration[:username],                        ## <<-- Used :user key  instead of :username
            :password => @configuration[:api_key],
            :ssl_client_cert => @configuration[:ssl_client_cert],
            :ssl_client_key => @configuration[:ssl_client_key],
            :ssl_ca_file => @configuration[:ssl_ca_file],
            :verify_ssl => @configuration[:verify_ssl]
        )
      end
     ```
4. **Error:**Removed default enabled SSL for Legacy API

      Because of this issue, when we try to configure and connect via Legacy API(**without SSL fields**), we get failure due to SSL.
     **Fixes:**
     `RestClient` by default enables SSL(when `:verify_ssl` key is not supplied), which was causing Legacy API to default to the same with or without SSL specifications in its API configuration. Updated `lib/bigcommerce/connection.rb` so that Legacy API does not default to SSL enabled form.
      ```
       resource_options = {
          :user => @configuration[:username],
          :password => @configuration[:api_key],
          :verify_ssl => OpenSSL::SSL::VERIFY_NONE,    ## <<--  Added this so that SSL is disabled when SSL fields are not supplied while configuring Legacy API
          :headers => headers
      }
      ```

