### PR TITLE
Move development dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,6 @@ gemspec
 
 group :development do
   gem 'pry'
-  gem 'rubocop'
   gem 'guard'
   gem 'guard-rspec'
-end
-
-group :test do
-  gem 'rspec'
-  gem 'simplecov'
-  gem 'coveralls'
 end

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -21,8 +21,11 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split($ORS)
   s.test_files = Dir['spec/**/*.rb']
 
-  s.add_development_dependency 'rake'
   s.add_development_dependency 'bundler'
+  s.add_development_dependency 'coveralls'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rubocop'
 
   s.add_dependency 'faraday'
   s.add_dependency 'faraday_middleware'


### PR DESCRIPTION
:information_desk_person: These changes explicitly move the development dependencies from the Gemfile to the gemspec for visibility and to aid keeping the code and dependency manifest in sync.

Fixes #93