### PR TITLE
Add required platform attribute to gemspec

### DIFF
--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -5,6 +5,7 @@ require 'bigcommerce/version'
 Gem::Specification.new do |s|
   s.name = 'bigcommerce'
   s.version = Bigcommerce::VERSION
+  s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 1.9.3'
   s.license = 'MIT'
 


### PR DESCRIPTION
:information_desk_person: The `platform` attribute is required by the [RubyGems gemspec specification][gemspec-spec]. This change sets it to the local operating system and architecture.

[gemspec-spec]: http://guides.rubygems.org/specification-reference/#platform=