### PR TITLE
make bigcommerce threadsafe

### DIFF
--- a/lib/bigcommerce.rb
+++ b/lib/bigcommerce.rb
@@ -20,15 +20,70 @@ module Bigcommerce
   }
 
   class << self
-    attr_reader :api
     attr_accessor :api_limit
 
     def configure
       config = Hashie::Mash.new
+
       yield(config)
+
+      @tenant_single_thread = build_client(config)
+    end
+
+    # keeps faraday api client for the duration of the thread
+    # ensures every thread has their own faraday api client.
+    @tenant_threadsafe = {}
+
+    # Threadsafe method of configuring bigcommerce.
+    #
+    # @example Rails controller
+    #
+    #     around_filter :configure_bigcommerce
+    #
+    #     protected
+    #
+    #     def configure_bigcommerce
+    #       config = {store_hash: session[:store_hash], client_id: "..", access_token: ".."}
+    #       Bigcommerce.configure_threadsafe(config) do
+    #         yield
+    #       end
+    #     end
+    #
+    def configure_threadsafe(config, &_block)
+      fail 'Already initialized with Bigcommerce.configure' if @tenant_single_thread
+      config = Hashie::Mash.new(config)
+      tenant = config.store_hash
+
+      @tenant_threadsafe[tenant] = build_client(config)
+
+      yield
+
+    ensure
+      # Make sure we don't leak memory
+      clear_thread!
+    end
+
+    def api
+      @tenant_single_thread || @tenant_threadsafe[tenant]
+    end
+
+    def clear_thread!
+      self.tenant = nil
+    end
+
+    def build_url(config)
+      return config.url if config.auth == 'legacy'
+
+      base = ENV['BC_API_ENDPOINT'].nil? ? DEFAULTS[:base_url] : ENV['BC_API_ENDPOINT']
+      "#{base}/stores/#{config.store_hash}/v2"
+    end
+
+    protected
+
+    def build_client(config)
       ssl_options = config.ssl if config.auth == 'legacy'
 
-      @api = Faraday.new(url: build_url(config), ssl: ssl_options) do |conn|
+      Faraday.new(url: build_url(config), ssl: ssl_options) do |conn|
         conn.request :json
         conn.headers = HEADERS
         if config.auth == 'legacy'
@@ -41,11 +96,12 @@ module Bigcommerce
       end
     end
 
-    def build_url(config)
-      return config.url if config.auth == 'legacy'
+    def tenant
+      Thread.current[:bc_api_tenant]
+    end
 
-      base = ENV['BC_API_ENDPOINT'].nil? ? DEFAULTS[:base_url] : ENV['BC_API_ENDPOINT']
-      "#{base}/stores/#{config.store_hash}/v2"
+    def tenant=(val)
+      Thread.current[:bc_api_tenant] = val
     end
   end
 end

--- a/lib/bigcommerce.rb
+++ b/lib/bigcommerce.rb
@@ -60,15 +60,12 @@ module Bigcommerce
 
     ensure
       # Make sure we don't leak memory
+      @tenant_threadsafe.delete(tenant)
       clear_thread!
     end
 
     def api
       @tenant_single_thread || @tenant_threadsafe[tenant]
-    end
-
-    def clear_thread!
-      self.tenant = nil
     end
 
     def build_url(config)
@@ -94,6 +91,11 @@ module Bigcommerce
         conn.use Bigcommerce::Middleware::HttpException
         conn.adapter Faraday.default_adapter
       end
+    end
+
+    def clear_thread!
+      @tenant_threadsafe[tenant]
+      self.tenant = nil
     end
 
     def tenant


### PR DESCRIPTION
I made a quick prototype on how to add threadsafety (Issue #98) without too much refactoring (which I think is crucial) 

Implementation is using `Thread.current`. I haven't tested it in real-life, as my bigcommerce dev account isn't active yet. 

Integration into rails would be like follows:

```ruby
around_filter :configure_bigcommerce

protected

def configure_bigcommerce
  config = {store_hash: session[:store_hash], client_id: "..", access_token: ".."}
  Bigcommerce.configure_threadsafe(config) do
    yield
  end
end
```

if this approach is ok for you i would finish this and add tests.