### PR TITLE
added metadata property

### DIFF
--- a/lib/bigcommerce/resources/customers/customer.rb
+++ b/lib/bigcommerce/resources/customers/customer.rb
@@ -23,8 +23,8 @@ module Bigcommerce
     property :addresses
     property :tax_exempt_category
 
-    def self.count
-      get 'customers/count'
+    def self.count(params = {})
+      get 'customers/count', params
     end
   end
 end

--- a/lib/bigcommerce/resources/products/product.rb
+++ b/lib/bigcommerce/resources/products/product.rb
@@ -89,6 +89,19 @@ module Bigcommerce
     property :tax_class
     property :avalara_product_tax_code
     property :primary_image
+    property :metadata, transform_with: (lambda do |value|
+      result = []
+      value.keys.each do |key|
+        value[key].each do |obj|
+          result << {
+            namespace: key,
+            key: obj.try(:[], :key),
+            value: obj.try(:[], :value)
+          }
+        end
+      end
+      result
+    end)
 
     def self.count(params = {})
       get 'products/count', params

--- a/lib/bigcommerce/resources/products/product.rb
+++ b/lib/bigcommerce/resources/products/product.rb
@@ -91,13 +91,16 @@ module Bigcommerce
     property :primary_image
     property :metadata, transform_with: (lambda do |value|
       result = []
-      value.keys.each do |key|
-        value[key].each do |obj|
-          result << {
-            namespace: key,
-            key: obj.try(:[], :key),
-            value: obj.try(:[], :value)
-          }
+
+      unless value.nil? || !value.is_a?(Hash)
+        value.keys.each do |key|
+          value[key].each do |obj|
+            result << {
+              namespace: key,
+              key: obj.try(:[], :key),
+              value: obj.try(:[], :value)
+            }
+          end
         end
       end
       result


### PR DESCRIPTION
This field was missing from the product resource, I'm guessing because it appears to come down in a different format than is required to create it or update it.  This works for what I know about metadata and how I use it for shipperhq integration.