### PR TITLE
Fix exception handling example typo

### DIFF
--- a/examples/exception_handling.rb
+++ b/examples/exception_handling.rb
@@ -42,7 +42,7 @@ rescue => e
   puts "Some other Error #{e.inspect}"
 end
 
-Bigcommerce::HttpError::ERRORS.each do |k, v|
+Bigcommerce::HttpErrors::ERRORS.each do |k, v|
   bc_handle_exception do
     # This will be your request that you want to protect from exceptions
     raise v, k


### PR DESCRIPTION
Before this PR:

```
$ ruby examples/exception_handling.rb
examples/exception_handling.rb:45:in `<main>': uninitialized constant Bigcommerce::HttpError::ERRORS (NameError)
```

After this PR:

```
$ ruby examples/exception_handling.rb
#<Bigcommerce::BadRequest: Bigcommerce::BadRequest>
#<Bigcommerce::Unauthorized: Bigcommerce::Unauthorized>
#<Bigcommerce::Forbidden: Bigcommerce::Forbidden>
#<Bigcommerce::NotFound: Bigcommerce::NotFound>
#<Bigcommerce::MethodNotAllowed: Bigcommerce::MethodNotAllowed>
#<Bigcommerce::NotAccepted: Bigcommerce::NotAccepted>
#<Bigcommerce::TimeOut: Bigcommerce::TimeOut>
#<Bigcommerce::ResourceConflict: Bigcommerce::ResourceConflict>
#<Bigcommerce::TooManyRequests: Bigcommerce::TooManyRequests>
#<Bigcommerce::InternalServerError: Bigcommerce::InternalServerError>
#<Bigcommerce::BadGateway: Bigcommerce::BadGateway>
#<Bigcommerce::ServiceUnavailable: Bigcommerce::ServiceUnavailable>
#<Bigcommerce::GatewayTimeout: Bigcommerce::GatewayTimeout>
#<Bigcommerce::BandwidthLimitExceeded: Bigcommerce::BandwidthLimitExceeded>
```