### PR TITLE
Update the SKU resource based on developer documentation

### DIFF
--- a/lib/bigcommerce/resources/products/sku.rb
+++ b/lib/bigcommerce/resources/products/sku.rb
@@ -7,16 +7,22 @@ module Bigcommerce
     include Bigcommerce::SubresourceActions.new uri: 'products/%d/skus/%d'
 
     property :id
-    property :product_id
     property :sku
-    property :cost_price
-    property :count
     property :upc
-    property :inventory_level
-    property :intentory_warning_level
-    property :bin_picking_number
+    property :price
+    property :weight
     property :options
+    property :cost_price
+    property :image_file
+    property :product_id
+    property :adjusted_price
+    property :adjusted_weight
+    property :inventory_level
+    property :bin_picking_number
+    property :is_purchasing_disabled
     property :inventory_warning_level
+    property :purchasing_disabled_message
+    property :count
 
     def self.count_all
       get 'products/skus/count'


### PR DESCRIPTION
Got a list of attributes from: https://developer.bigcommerce.com/api/objects/v2/sku

Fixes #110 

Ex response:

```rb
Bigcommerce::Sku.all(4)
=> [#<Bigcommerce::Sku adjusted_price="12345.0000" adjusted_weight="123.0000" bin_picking_number="1234567" cost_price="123.0000" id=18 image_file="" inventory_level=0 inventory_warning_level=0 is_purchasing_disabled=false options=[{:product_option_id=>1, :option_value_id=>73}] price="12345.0000" product_id=4 purchasing_disabled_message="" sku="fdjhjk" upc="djksbgkjsdb" weight="123.0000">]
```