### PR TITLE
Update BlogPost resource to have correct attributes

### DIFF
--- a/lib/bigcommerce/resources/content/blog_post.rb
+++ b/lib/bigcommerce/resources/content/blog_post.rb
@@ -8,21 +8,19 @@ module Bigcommerce
 
     property :id
     property :url
-    property :count
     property :preview_url
     property :body
     property :tags
     property :summary
     property :title
-    property :content
     property :author
     property :author_url
     property :is_published
     property :published_date
-    property :published_at
     property :meta_description
     property :meta_keywords
     property :thumbnail_path
+    property :count
 
     def self.count
       get 'blog/posts/count'


### PR DESCRIPTION
The removed attributes are unused in the current api and can safely be removed.

See: https://developer.bigcommerce.com/api/stores/v2/blog/posts