### PR TITLE
Update BlogTag resource

### DIFF
--- a/lib/bigcommerce/resources/content/blog_tag.rb
+++ b/lib/bigcommerce/resources/content/blog_tag.rb
@@ -6,7 +6,6 @@ module Bigcommerce
   class BlogTag < Resource
     include Bigcommerce::Request.new 'blog/tags'
 
-    property :id
     property :tag
     property :post_ids
 


### PR DESCRIPTION
The `id` field is not used.

Based on information from: https://developer.bigcommerce.com/api/stores/v2/blog/tags

Ex.

```
$ ruby examples/content/blog_tag.rb
#<Bigcommerce::BlogTag post_ids=[1] tag="Blog">
#<Bigcommerce::BlogTag post_ids=[1] tag="Seo">
```