### PR TITLE
Update the GiftCertificate example

### DIFF
--- a/examples/marketing/gift_certificates.rb
+++ b/examples/marketing/gift_certificates.rb
@@ -1,4 +1,5 @@
 require 'bigcommerce'
+require 'securerandom'
 
 Bigcommerce.configure do |config|
   config.auth = 'legacy'
@@ -9,14 +10,14 @@ Bigcommerce.configure do |config|
 end
 
 # List gift certificates
-@gift_certificates = Bigcommerce::Giftcertificates.all
+@gift_certificates = Bigcommerce::GiftCertificates.all
 puts @gift_certificates
 
 # Get a gift certificate
 puts Bigcommerce::GiftCertificates.find(@gift_certificates.first.id)
 
 # Create a gift certificate
-@gift_certificates = Bigcommerce::GiftCertificates.create(
+@gift_certificate = Bigcommerce::GiftCertificates.create(
   to_name:    'Test',
   to_email:   'test@test.com',
   from_name:  'Test2',
@@ -24,7 +25,7 @@ puts Bigcommerce::GiftCertificates.find(@gift_certificates.first.id)
   code:       SecureRandom.hex,
   amount:     100
 )
-puts @gift_certificates
+puts @gift_certificate
 
 # Update an instance of a gift certificate
 puts @gift_certificates.first.update(balance: 50)
@@ -36,4 +37,4 @@ puts Bigcommerce::GiftCertificates.update(@gift_certificates.first.id, balance: 
 puts Bigcommerce::GiftCertificates.destroy(@gift_certificates.first.id)
 
 # Delete all gift certificates
-puts Bigcommerce::GiftCertificates.destroy_all
+# puts Bigcommerce::GiftCertificates.destroy_all


### PR DESCRIPTION
There was a typo which caused this example to not work.

```
$ ruby examples/marketing/gift_certificates.rb
#<Bigcommerce::GiftCertificates amount="100.0000" balance="100.0000" code="98679a2eef4573465f12" customer_id="0" expiry_date="0" from_email="othertest@test.com" from_name="Test2" id=7 message="" order_id="0" purchase_date="1466472031" status="0" template=false to_email="test@test.com" to_name="Test">
#<Bigcommerce::GiftCertificates amount="100.0000" balance="100.0000" code="98679a2eef4573465f12" customer_id="0" expiry_date="0" from_email="othertest@test.com" from_name="Test2" id=7 message="" order_id="0" purchase_date="1466472031" status="0" template=false to_email="test@test.com" to_name="Test">
#<Bigcommerce::GiftCertificates amount="100.0000" balance="100.0000" code="f91742357440bdbd74b2" customer_id="0" expiry_date="0" from_email="othertest@test.com" from_name="Test2" id=8 message="" order_id="0" purchase_date="1466472035" status="0" template=false to_email="test@test.com" to_name="Test">
#<Bigcommerce::GiftCertificates amount="100.0000" balance=50 code="98679a2eef4573465f12" customer_id="0" expiry_date="0" from_email="othertest@test.com" from_name="Test2" id=7 message="" order_id="0" purchase_date="1466472031" status="0" template=false to_email="test@test.com" to_name="Test">
#<Bigcommerce::GiftCertificates amount="100.0000" balance="50.0000" code="98679a2eef4573465f12" customer_id="0" expiry_date="0" from_email="othertest@test.com" from_name="Test2" id=7 message="" order_id="0" purchase_date="1466472031" status="0" template=false to_email="test@test.com" to_name="Test">
```