### PR TITLE
Handle gzipped response bodies with FaradayMiddleware::Gzip

### DIFF
--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -18,6 +18,7 @@ module Bigcommerce
           conn.use Bigcommerce::Middleware::Auth, config
         end
         conn.use Bigcommerce::Middleware::HttpException
+        conn.use FaradayMiddleware::Gzip
         conn.adapter Faraday.default_adapter
       end
     end


### PR DESCRIPTION
#### What?
#136 adds the `accept-encoding: gzip` header to requests, but does not handle gzip-encoded respnoses. This adds `FaradayMiddleware::Gzip` to the middleware stack to handle requested gzip-encoded bodies.
