### PR TITLE
add form_fields to Customer

### DIFF
--- a/lib/bigcommerce/resources/customers/customer.rb
+++ b/lib/bigcommerce/resources/customers/customer.rb
@@ -26,6 +26,7 @@ module Bigcommerce
     property :addresses
     property :tax_exempt_category
     property :accepts_marketing
+    property :form_fields
 
     def self.count(params = {})
       get 'customers/count', params


### PR DESCRIPTION
Form fields exist on Customer but are missing from the customer resource object.

Schema definition:

```
  $ curl https://developer.bigcommerce.com/api-reference/store-management/customers-v2/BigCommerce_Customers_API.oas2.json \
   | jq '.definitions.Customer.properties.form_fields'
```

```javascript
  {
    "description": "Array of custom fields. This is a READ-ONLY field; do not set or modify its value in a POST or PUT request.",
    "type": "array",
    "items": {
      "title": "Form Fields",
      "type": "object",
      "properties": {
        "name": {
          "description": "Name of the form field",
          "type": "string",
          "example": "License Id"
        },
        "value": {
          "description": "Value of the form field",
          "type": "string",
          "example": "123BAF"
        }
      }
    }
  }
```