### PR TITLE
Fix Bigcommerce::Customer#login_token JWT

### DIFF
--- a/lib/bigcommerce/resources/customers/customer.rb
+++ b/lib/bigcommerce/resources/customers/customer.rb
@@ -44,7 +44,7 @@ module Bigcommerce
         'customer_id' => id
       }
 
-      JWT.encode(payload, config.client_secret, 'HS256')
+      JWT.encode(payload, config.client_secret, 'HS256', { typ: 'JWT' })
     end
   end
 end

--- a/lib/bigcommerce/resources/customers/customer.rb
+++ b/lib/bigcommerce/resources/customers/customer.rb
@@ -34,14 +34,15 @@ module Bigcommerce
     # Generate a token that can be used to log the customer into the storefront.
     # This requires your app to have the store_v2_customers_login scope and to
     # be installed in the store.
-    def login_token(config: Bigcommerce.config)
+    def login_token(config: Bigcommerce.config, redirect_to: '/')
       payload = {
         'iss' => config.client_id,
         'iat' => Time.now.to_i,
         'jti' => SecureRandom.uuid,
         'operation' => 'customer_login',
         'store_hash' => config.store_hash,
-        'customer_id' => id
+        'customer_id' => id,
+        'redirect_to' => redirect_to
       }
 
       JWT.encode(payload, config.client_secret, 'HS256', { typ: 'JWT' })


### PR DESCRIPTION
`Bigcommerce::Customer#login_token` does not create valid JWTs. 

- Add missing `typ` header
- Add missing `redirect_to` payload option
