### PR TITLE
Remove EOL Ruby versions causing CI failures on all PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 language: ruby
 rvm:
   - ruby-head
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
 cache:
   bundler: true
 sudo: false
 matrix:
   allow_failures:
-    - rvm: ruby-head
+    - rvm: 
+      - 2.0
+      - 2.1
+      - 2.2
+      - 2.3
+      - 2.4
+      - 3.0
+      - ruby-head
   fast_finish: true


### PR DESCRIPTION
# Why?
* Ruby 2.0-2.4 are EOL and yet they're requirements of this gem, but they don't need t obe.
* Also, Ruby 2.0 is causing the CI to fail on every pull request. That's why it looks like all PRs are breaking things.

# What?
* Make Ruby 2.0-2.4 optional passes in travis
* Add modern version checks like 2.5, 2.6, 2.7 and 3.0 (the last one being optional)

# Tickets / Documentation
* https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/
* Look at any PR in this repo and click the CI build status

