### PR TITLE
Update JWT and Hashie gem requirements

### DIFF
--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '~> 0.11'
   s.add_dependency 'faraday_middleware', '~> 0.11'
-  s.add_dependency 'hashie', '~> 3.4'
-  s.add_dependency 'jwt', '~> 1.5.4'
+  s.add_dependency 'hashie', '>= 3.4', '~> 4'
+  s.add_dependency 'jwt', '>= 1.5.4', '~> 2'
 end


### PR DESCRIPTION
# Why?
* The current version requirements of this gem for JWT and Hashie gems are highly outdated and cause major compatibility issues with basically any other modern gems (like omniauth or Google api gems).

# What?
* Update JWT and Hashie gems to be able to get newer versions since 

Specs appear to be passing, and update was battle-tested at @feracommerce 

# Tickets / Documentation
* I checked the [change logs for Hashie gem here](https://github.com/hashie/hashie/releases) to ensure that there are no breaking changes
* I checked the [change logs for JWT gem here](https://github.com/jwt/ruby-jwt/releases) to ensure that there are no breaking changes

JWT update seems to have added a ton of fixes as well that should be allowed.