### PR TITLE
APPEX-243: adds case-insensitive handling for HTTP header titles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
     - vendor/**/*
     - examples/**/*
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Metrics/AbcSize:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next Release
 Your contribution here.
 
+* [#167](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/000): Changes handling of HTTP response headers to handle lowercased titles. - [@bc-zachary](https://github.com/bc-zachary).
 * [#000](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/000): Brief description here. - [@username](https://github.com/username).
 
 ## 1.0.1

--- a/spec/bigcommerce/unit/exception_spec.rb
+++ b/spec/bigcommerce/unit/exception_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Bigcommerce::HttpErrors do
 
   before do
     allow(env).to receive(:body) { body }
-    allow(env).to receive(:[]) { headers }
+    allow(env).to receive(:response_headers) { headers }
   end
 
   it '::ERRORS is not nil' do
@@ -32,6 +32,20 @@ RSpec.describe Bigcommerce::HttpErrors do
     context 'when have a body and response headers' do
       let(:body) { JSON.generate({ time: '1426184190' }) }
       let(:headers) { { 'X-Retry-After' => 1 } }
+      let(:code) { 429 }
+
+      it 'should parse out a retry-after header if present' do
+        begin
+          dummy_class.throw_http_exception!(code, env)
+        rescue Bigcommerce::TooManyRequests => e
+          expect(e.response_headers[:retry_after]).to eq 1
+        end
+      end
+    end
+
+    context 'when have a body and lowercase response headers' do
+      let(:body) { JSON.generate({ time: '1426184190' }) }
+      let(:headers) { { 'x-retry-after' => 1 } }
       let(:code) { 429 }
 
       it 'should parse out a retry-after header if present' do


### PR DESCRIPTION
#### What?

Updates how response headers are handled to accommodate lowercased header names. New unit test included to verify functionality. Plus an edit in `.rubocop.yml` to get rid of a rubocop error.