### PR TITLE
Loosen Faraday dependency to ~> 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Next Release
 Your contribution here.
 
+* [#000](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/000): Brief description here. - [@username](https://github.com/username).
+
+## 1.0.2
+
 * [#173](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/173): Loosen Faraday dependency to ~> 1.1.0 - [@bc-johnhebron](https://github.com/bc-johnhebron).
 * [#159](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/159): Added new missing fields for an order - [@ranjeetkumarkanaily](https://github.com/ranjeetkumarkanaily).
 * [#171](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/171): Fix various Rubocop warnings and declare dotenv as a dev dependency - [@splittingred](https://github.com/splittingred).
@@ -8,7 +12,6 @@ Your contribution here.
 * [#169](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/169): Move to CircleCI off of TravisCI - [@splittingred](https://github.com/splittingred).
 * [#168](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/168): Explicitly declare development dependencies in gemspec - [@splittingred](https://github.com/splittingred).
 * [#167](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/167): Changes handling of HTTP response headers to handle lowercased titles. - [@bc-zachary](https://github.com/bc-zachary).
-* [#000](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/000): Brief description here. - [@username](https://github.com/username).
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,20 @@
 ## Next Release
 Your contribution here.
 
-* [#170](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/170): Fix various Rubocop warnings and declare dotenv as a dev dependency - [@splittingred](https://github.com/splittingred)
-* [#169](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/169): Add frozen_string_literal magic comment to all files - [@splittingred](https://github.com/splittingred)
-* [#168](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/168): Move to CircleCI off of TravisCI - [@splittingred](https://github.com/splittingred)
-* [#168](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/168): Explicitly declare development dependencies in gemspec - [@splittingred](https://github.com/splittingred)
+* [#173](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/173): Loosen Faraday dependency to ~> 1.1.0 - [@bc-johnhebron](https://github.com/bc-johnhebron).
+* [#159](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/159): Added new missing fields for an order - [@ranjeetkumarkanaily](https://github.com/ranjeetkumarkanaily).
+* [#171](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/171): Fix various Rubocop warnings and declare dotenv as a dev dependency - [@splittingred](https://github.com/splittingred).
+* [#170](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/170): Add frozen_string_literal magic comment to all files - [@splittingred](https://github.com/splittingred).
+* [#169](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/169): Move to CircleCI off of TravisCI - [@splittingred](https://github.com/splittingred).
+* [#168](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/168): Explicitly declare development dependencies in gemspec - [@splittingred](https://github.com/splittingred).
 * [#167](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/167): Changes handling of HTTP response headers to handle lowercased titles. - [@bc-zachary](https://github.com/bc-zachary).
 * [#000](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/000): Brief description here. - [@username](https://github.com/username).
 
 ## 1.0.1
 
-* [#148](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/148): Loosen Faraday version dependency pin. Update license to explicit MIT. Fix Rubocop and Travis builds. - [@splittingred](https://github.com/splittingred)
-* [#142](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/142): Update Faraday gem version. Add support for OAuth SSL options. - [@pedelman](https://github.com/pedelman)
-* [#136](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/136): Added accept-encoding: gzip header. - [@adambilsing](https://github.com/adambilsing)
+* [#148](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/148): Loosen Faraday version dependency pin. Update license to explicit MIT. Fix Rubocop and Travis builds. - [@splittingred](https://github.com/splittingred).
+* [#142](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/142): Update Faraday gem version. Add support for OAuth SSL options. - [@pedelman](https://github.com/pedelman).
+* [#136](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/136): Added accept-encoding: gzip header. - [@adambilsing](https://github.com/adambilsing).
 * [#128](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/128): Added support for token generation for storefront login. - [@mattolson](https://github.com/mattolson).
 
 ## 1.0.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ bundle install
 bundle exec rake
 ```
 
-This will ensure both style and that all the specs pass locally. Next, check that the last build succeeded in [Travis CI](https://travis-ci.org/bigcommerce/bigcommerce-api-ruby) for all supported platforms.
+This will ensure both style and that all the specs pass locally. Next, check that the last build succeeded in [CircleCI](https://app.circleci.com/pipelines/github/bigcommerce/bigcommerce-api-ruby) for all supported platforms.
 
 Increment the version, modify [lib/bigcommerce/version.rb](lib/bigcommerce/version.rb).
 

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-performance', '>= 1.5'
   s.add_development_dependency 'simplecov', '~> 0.15'
 
-  s.add_dependency 'faraday', '~> 0.11'
-  s.add_dependency 'faraday_middleware', '~> 0.11'
+  s.add_dependency 'faraday', '~> 1.1.0'
+  s.add_dependency 'faraday_middleware', '~> 1.0'
   s.add_dependency 'hashie', '>= 3.4', '~> 4'
   s.add_dependency 'jwt', '>= 1.5.4', '~> 2'
 end

--- a/lib/bigcommerce/config.rb
+++ b/lib/bigcommerce/config.rb
@@ -22,7 +22,7 @@ module Bigcommerce
     # @return [String]
     #
     def base_url
-      ENV[BC_API_ENDPOINT_ENV_KEY].to_s.empty? ? DEFAULTS[:base_url] : ENV[BC_API_ENDPOINT_ENV_KEY]
+      ENV[BC_API_ENDPOINT_ENV_KEY].to_s.empty? ? DEFAULTS[:base_url] : ENV.fetch(BC_API_ENDPOINT_ENV_KEY, nil)
     end
   end
 end

--- a/lib/bigcommerce/resources/orders/order.rb
+++ b/lib/bigcommerce/resources/orders/order.rb
@@ -77,7 +77,6 @@ module Bigcommerce
     property :store_default_currency_code
     property :store_default_to_transactional_exchange_rate
     property :tax_provider_id
-    
 
     def self.count(params = {})
       get 'orders/count', params

--- a/lib/bigcommerce/version.rb
+++ b/lib/bigcommerce/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bigcommerce
-  VERSION = '1.0.2.pre'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
#### What?

Updating the Faraday gem from 0.17.x to 1.1.x.

Misc:
* correcting entries in the CHANGELOG.md

#### Tickets / Documentation

The Faraday changelogs can be reviewed here:

- [0.17.4](https://github.com/lostisland/faraday/blob/main/CHANGELOG.md#v0174)
- [1.1.0](https://github.com/lostisland/faraday/blob/main/CHANGELOG.md#v110-2020-10-17)

#### Screenshots (if appropriate)

* RSpec tests pass
* Tested creating a client and manipulating resources successfully
* 
<img width="1535" alt="Screen Shot 2022-08-26 at 2 23 51 PM" src="https://user-images.githubusercontent.com/7632624/186977554-23a1664d-90d5-4060-8468-0866e2831ef4.png">

