### PR TITLE
Add 423 Locked Status exception

### DIFF
--- a/lib/bigcommerce/exception.rb
+++ b/lib/bigcommerce/exception.rb
@@ -18,6 +18,7 @@ module Bigcommerce
   class NotAccepted < HttpError; end
   class TimeOut < HttpError; end
   class ResourceConflict < HttpError; end
+  class LockedStatus < HttpError; end
   class TooManyRequests < HttpError; end
   class InternalServerError < HttpError; end
   class BadGateway < HttpError; end
@@ -35,6 +36,7 @@ module Bigcommerce
       406 => Bigcommerce::NotAccepted,
       408 => Bigcommerce::TimeOut,
       409 => Bigcommerce::ResourceConflict,
+      423 => Bigcommerce::LockedStatus,
       429 => Bigcommerce::TooManyRequests,
       500 => Bigcommerce::InternalServerError,
       502 => Bigcommerce::BadGateway,


### PR DESCRIPTION
#### What?

`423` - The requested resource is currently locked and unavailable.

Effectively meaning the store is down or on a maintenance.

Existing tests covers all ERRORS defined: https://github.com/bigcommerce/bigcommerce-api-ruby/blob/master/spec/bigcommerce/unit/exception_spec.rb#L28-L31

#### Tickets / Documentation

- https://developer.bigcommerce.com/api-docs/getting-started/api-status-codes