### PR TITLE
Preparing for release, 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 Your contribution here.
 
 * [#000](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/000): Brief description here. - [@username](https://github.com/username).
+
+## 1.1.0
 * [#174](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/174): Drop support for ruby 2.6; Add support for Ruby 3.2 - [@j05h](https://github.com/j05h).
 
 ## 1.0.2

--- a/lib/bigcommerce/version.rb
+++ b/lib/bigcommerce/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bigcommerce
-  VERSION = '1.1.0.pre'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
#### What?

Preparations for 1.1.0 release, which supports Ruby 3.2.