### PR TITLE
Update Faraday to v2.12.2 and refactor middleware usage

### DIFF
--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.files = Dir['README.md', 'lib/**/*', 'bigcommerce.gemspec']
 
-  s.add_dependency 'faraday', '~> 1.1.0'
-  s.add_dependency 'faraday_middleware', '~> 1.0'
+  s.add_dependency 'faraday', '~> 2.12.2'
+  s.add_dependency 'faraday-gzip', '~> 3'
   s.add_dependency 'hashie', '>= 3.4', '~> 4'
   s.add_dependency 'jwt', '>= 1.5.4', '~> 2'
 end

--- a/lib/bigcommerce.rb
+++ b/lib/bigcommerce.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require 'hashie'
-require 'faraday_middleware'
+require 'faraday'
+require 'faraday/gzip'
 require_relative 'bigcommerce/version'
 require_relative 'bigcommerce/config'
 require_relative 'bigcommerce/connection'

--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'faraday/gzip'
+
 module Bigcommerce
   module Connection
     LEGACY_AUTH_MODE = 'legacy'
@@ -14,14 +16,14 @@ module Bigcommerce
       ssl_options = config.ssl || {}
       Faraday.new(url: config.api_url, ssl: ssl_options) do |conn|
         conn.request :json
+        conn.request :gzip
         conn.headers = HEADERS
         if config.auth == LEGACY_AUTH_MODE
-          conn.use Faraday::Request::BasicAuthentication, config.username, config.api_key
+          conn.request :authorization, :basic, config.username, config.api_key
         else
           conn.use Bigcommerce::Middleware::Auth, config
         end
         conn.use Bigcommerce::Middleware::HttpException
-        conn.use FaradayMiddleware::Gzip
         conn.adapter Faraday.default_adapter
       end
     end

--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday/gzip'
-
 module Bigcommerce
   module Connection
     LEGACY_AUTH_MODE = 'legacy'

--- a/lib/bigcommerce/middleware/auth.rb
+++ b/lib/bigcommerce/middleware/auth.rb
@@ -7,15 +7,14 @@ module Bigcommerce
       X_AUTH_TOKEN_HEADER = 'X-Auth-Token'
 
       def initialize(app, options = {})
-        @app = app
-        @options = options
         super(app)
+        @options = options
       end
 
       def call(env)
         env[:request_headers][X_AUTH_CLIENT_HEADER] = @options[:client_id]
         env[:request_headers][X_AUTH_TOKEN_HEADER] = @options[:access_token]
-        @app.call env
+        @app.call(env)
       end
     end
   end

--- a/lib/bigcommerce/middleware/http_exception.rb
+++ b/lib/bigcommerce/middleware/http_exception.rb
@@ -4,11 +4,11 @@ require 'bigcommerce/exception'
 
 module Bigcommerce
   module Middleware
-    class HttpException < Faraday::Response::Middleware
+    class HttpException < Faraday::Middleware
       include Bigcommerce::HttpErrors
 
       def on_complete(env)
-        throw_http_exception! env[:status].to_i, env
+        throw_http_exception!(env[:status].to_i, env)
         env
       end
     end

--- a/spec/bigcommerce/bigcommerce_spec.rb
+++ b/spec/bigcommerce/bigcommerce_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Bigcommerce do
       end
 
       it 'should have the correct auth middleware' do
-        expect(middleware).to include(Faraday::Request::BasicAuthentication)
+        expect(middleware).to include(Faraday::Request::Authorization)
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Bigcommerce do
 
       expect(Bigcommerce.api.instance_variable_get('@builder')
                 .instance_variable_get('@handlers'))
-                .to include(Faraday::Request::BasicAuthentication)
+                .to include(Faraday::Request::Authorization)
 
       Bigcommerce.configure do |config|
         config.access_token = 'jksdgkjbhksjdb'


### PR DESCRIPTION
- Updated gemspec to use Faraday v2.12.2 and added faraday-gzip dependency
- Refactored connection.rb to use Faraday::Request::Authorization for legacy auth
- Updated bigcommerce.rb to require faraday/gzip
- Refactored Bigcommerce::Middleware::Auth and Bigcommerce::Middleware::HttpException for compatibility with Faraday v2
- Updated RSpec tests to reflect changes in middleware usage