### PR TITLE
Update dependencies and middleware for Faraday integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,6 @@ orbs:
 defaults: &defaults
   notify_failure: false
 
-ruby_2_7_defaults: &ruby_2_7_defaults
-  <<: *defaults
-  e:
-    name: ruby/ruby
-    ruby-version: '2.7'
-
 ruby_3_0_defaults: &ruby_3_0_defaults
   <<: *defaults
   e:
@@ -39,19 +33,6 @@ ruby_3_4_defaults: &ruby_3_4_defaults
 
 workflows:
   version: 2
-  ruby_2_7:
-    jobs:
-      - ruby/bundle-audit:
-          <<: *ruby_2_7_defaults
-          name: ruby-2_7-bundle_audit
-      - ruby/rubocop:
-          <<: *ruby_2_7_defaults
-          name: ruby-2_7-rubocop
-      - ruby/rspec-unit:
-          <<: *ruby_2_7_defaults
-          name: ruby-2_7-rspec_unit
-          db: false
-          code-climate: false
   ruby_3_0:
     jobs:
       - ruby/bundle-audit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,12 @@ ruby_3_2_defaults: &ruby_3_2_defaults
     name: ruby/ruby
     ruby-version: '3.2'
 
+ruby_3_4_defaults: &ruby_3_4_defaults
+  <<: *defaults
+  e:
+    name: ruby/ruby
+    ruby-version: '3.4'
+
 workflows:
   version: 2
   ruby_2_7:
@@ -82,5 +88,18 @@ workflows:
       - ruby/rspec-unit:
           <<: *ruby_3_2_defaults
           name: ruby-3_2-rspec_unit
+          db: false
+          code-climate: false
+  ruby_3_4:
+    jobs:
+      - ruby/bundle-audit:
+          <<: *ruby_3_4_defaults
+          name: ruby-3_4-bundle_audit
+      - ruby/rubocop:
+          <<: *ruby_3_4_defaults
+          name: ruby-3_4-rubocop
+      - ruby/rspec-unit:
+          <<: *ruby_3_4_defaults
+          name: ruby-3_4-rspec_unit
           db: false
           code-climate: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Your contribution here.
 
 * [#000](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/000): Brief description here. - [@username](https://github.com/username).
 
+## 2.0.0
+
+* [#186](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/186): Update to Faraday 2.14 and add support for Ruby 3.4 - [@markcmurphy](https://github.com/markcmurphy).
+  
 ## 1.1.0
 * [#174](https://github.com/bigcommerce/bigcommerce-api-ruby/pull/174): Drop support for ruby 2.6; Add support for Ruby 3.2 - [@j05h](https://github.com/j05h).
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -3,6 +3,5 @@
 Many thanks to the contributors and authors of the following libraries!
 
 - [Faraday](https://github.com/lostisland/faraday) Simple, but flexible HTTP client library, with support for multiple backends. - [MIT](https://github.com/lostisland/faraday/blob/master/LICENSE.md)
-- [Faraday Middleware](https://github.com/lostisland/faraday_middleware) Various Faraday middlewares for Faraday-based API wrappers. - [MIT](https://github.com/lostisland/faraday_middleware/blob/master/LICENSE.md)
 - [Hashie](https://github.com/intridea/hashie) Hashie is a collection of classes and mixins that make hashes more powerful. - [MIT](https://github.com/intridea/hashie/blob/master/LICENSE)
 - [JWT](https://github.com/jwt/ruby-jwt) Used to encode and sign JWT tokens for the Customer Login API. - [MIT](https://github.com/jwt/ruby-jwt/blob/master/LICENSE)

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -3,5 +3,6 @@
 Many thanks to the contributors and authors of the following libraries!
 
 - [Faraday](https://github.com/lostisland/faraday) Simple, but flexible HTTP client library, with support for multiple backends. - [MIT](https://github.com/lostisland/faraday/blob/master/LICENSE.md)
+- [Faraday Gzip](https://github.com/bodrovis/faraday-gzip) Gzip request and response compression middleware for Faraday. - [MIT](https://github.com/bodrovis/faraday-gzip/blob/main/LICENSE.txt)
 - [Hashie](https://github.com/intridea/hashie) Hashie is a collection of classes and mixins that make hashes more powerful. - [MIT](https://github.com/intridea/hashie/blob/master/LICENSE)
 - [JWT](https://github.com/jwt/ruby-jwt) Used to encode and sign JWT tokens for the Customer Login API. - [MIT](https://github.com/jwt/ruby-jwt/blob/master/LICENSE)

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.files = Dir['README.md', 'lib/**/*', 'bigcommerce.gemspec']
 
   s.add_dependency 'faraday', '>= 2.14', '< 3.0'
+  s.add_dependency 'faraday-gzip', '~> 3.0'
   s.add_dependency 'hashie', '>= 3.4', '~> 4'
   s.add_dependency 'jwt', '>= 1.5.4', '~> 2'
 end

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.files = Dir['README.md', 'lib/**/*', 'bigcommerce.gemspec']
 
-  s.add_dependency 'faraday', '~> 1.1.0'
-  s.add_dependency 'faraday_middleware', '~> 1.0'
+  s.add_dependency 'faraday', '>= 2.14', '< 3.0'
   s.add_dependency 'hashie', '>= 3.4', '~> 4'
   s.add_dependency 'jwt', '>= 1.5.4', '~> 2'
 end

--- a/lib/bigcommerce.rb
+++ b/lib/bigcommerce.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'hashie'
-require 'faraday_middleware'
+require 'faraday'
 require_relative 'bigcommerce/version'
 require_relative 'bigcommerce/config'
 require_relative 'bigcommerce/connection'

--- a/lib/bigcommerce.rb
+++ b/lib/bigcommerce.rb
@@ -2,6 +2,7 @@
 
 require 'hashie'
 require 'faraday'
+require 'faraday/gzip'
 require_relative 'bigcommerce/version'
 require_relative 'bigcommerce/config'
 require_relative 'bigcommerce/connection'

--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -20,6 +20,7 @@ module Bigcommerce
         else
           conn.use Bigcommerce::Middleware::Auth, config
         end
+        conn.request :gzip
         conn.use Bigcommerce::Middleware::HttpException
         conn.adapter Faraday.default_adapter
       end

--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -16,12 +16,11 @@ module Bigcommerce
         conn.request :json
         conn.headers = HEADERS
         if config.auth == LEGACY_AUTH_MODE
-          conn.use Faraday::Request::BasicAuthentication, config.username, config.api_key
+          conn.request :authorization, :basic, config.username, config.api_key
         else
           conn.use Bigcommerce::Middleware::Auth, config
         end
         conn.use Bigcommerce::Middleware::HttpException
-        conn.use FaradayMiddleware::Gzip
         conn.adapter Faraday.default_adapter
       end
     end

--- a/lib/bigcommerce/middleware/auth.rb
+++ b/lib/bigcommerce/middleware/auth.rb
@@ -6,10 +6,6 @@ module Bigcommerce
       X_AUTH_CLIENT_HEADER = 'X-Auth-Client'
       X_AUTH_TOKEN_HEADER = 'X-Auth-Token'
 
-      def initialize(app, options = {})
-        super
-      end
-
       def call(env)
         env[:request_headers][X_AUTH_CLIENT_HEADER] = option_value(:client_id)
         env[:request_headers][X_AUTH_TOKEN_HEADER] = option_value(:access_token)
@@ -19,7 +15,9 @@ module Bigcommerce
       private
 
       def option_value(key)
-        @options[key] || @options[key.to_s]
+        return @options[key] if @options.key?(key)
+
+        @options[key.to_s]
       end
     end
   end

--- a/lib/bigcommerce/middleware/auth.rb
+++ b/lib/bigcommerce/middleware/auth.rb
@@ -11,9 +11,15 @@ module Bigcommerce
       end
 
       def call(env)
-        env[:request_headers][X_AUTH_CLIENT_HEADER] = @options[:client_id]
-        env[:request_headers][X_AUTH_TOKEN_HEADER] = @options[:access_token]
+        env[:request_headers][X_AUTH_CLIENT_HEADER] = option_value(:client_id)
+        env[:request_headers][X_AUTH_TOKEN_HEADER] = option_value(:access_token)
         @app.call env
+      end
+
+      private
+
+      def option_value(key)
+        @options[key] || @options[key.to_s]
       end
     end
   end

--- a/lib/bigcommerce/middleware/auth.rb
+++ b/lib/bigcommerce/middleware/auth.rb
@@ -7,9 +7,7 @@ module Bigcommerce
       X_AUTH_TOKEN_HEADER = 'X-Auth-Token'
 
       def initialize(app, options = {})
-        @app = app
-        @options = options
-        super(app)
+        super
       end
 
       def call(env)

--- a/lib/bigcommerce/middleware/http_exception.rb
+++ b/lib/bigcommerce/middleware/http_exception.rb
@@ -4,8 +4,14 @@ require 'bigcommerce/exception'
 
 module Bigcommerce
   module Middleware
-    class HttpException < Faraday::Response::Middleware
+    class HttpException < Faraday::Middleware
       include Bigcommerce::HttpErrors
+
+      def call(env)
+        @app.call(env).on_complete do |response_env|
+          on_complete(response_env)
+        end
+      end
 
       def on_complete(env)
         throw_http_exception! env[:status].to_i, env

--- a/lib/bigcommerce/request.rb
+++ b/lib/bigcommerce/request.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'stringio'
+require 'zlib'
 
 module Bigcommerce
   class Request < Module
@@ -46,7 +48,7 @@ module Bigcommerce
       private
 
       def build_response_object(response)
-        json = parse response.body
+        json = parse(response.body, response.headers)
         if json.is_a? Array
           json.map { |obj| new obj }
         else
@@ -58,10 +60,22 @@ module Bigcommerce
       # @return [Hash]
       # @return [Array]
       #
-      def parse(json)
+      def parse(json, headers = {})
         return [] if json.empty?
 
-        JSON.parse(json, symbolize_names: true)
+        JSON.parse(decode_body(json, headers), symbolize_names: true)
+      end
+
+      def decode_body(body, headers = {})
+        payload = body.to_s.dup.force_encoding(Encoding::BINARY)
+        return payload if payload.empty?
+
+        content_encoding = headers['content-encoding'] || headers[:content_encoding]
+        return payload unless content_encoding.to_s.downcase.include?('gzip') || payload.start_with?("\x1F\x8B".b)
+
+        Zlib::GzipReader.new(StringIO.new(payload)).read
+      rescue Zlib::Error
+        payload
       end
     end
   end

--- a/lib/bigcommerce/request.rb
+++ b/lib/bigcommerce/request.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'stringio'
-require 'zlib'
 
 module Bigcommerce
   class Request < Module
@@ -27,7 +25,7 @@ module Bigcommerce
 
       def delete(path, params = {})
         response = raw_request(:delete, path, params)
-        decode_body(response.body, response.headers)
+        response.body
       end
 
       def post(path, params = {})
@@ -42,17 +40,13 @@ module Bigcommerce
 
       def raw_request(method, path, params = {})
         client = params.delete(:connection) || Bigcommerce.api
-        response = client.send(method, path.to_s, params)
-        return response unless response.respond_to?(:body) && response.respond_to?(:body=)
-
-        response.body = decode_body(response.body, response.respond_to?(:headers) ? response.headers : {})
-        response
+        client.send(method, path.to_s, params)
       end
 
       private
 
       def build_response_object(response)
-        json = parse(response.body, response.headers)
+        json = parse(response.body)
         if json.is_a? Array
           json.map { |obj| new obj }
         else
@@ -64,22 +58,10 @@ module Bigcommerce
       # @return [Hash]
       # @return [Array]
       #
-      def parse(json, headers = {})
+      def parse(json)
         return [] if json.empty?
 
-        JSON.parse(decode_body(json, headers), symbolize_names: true)
-      end
-
-      def decode_body(body, headers = {})
-        payload = body.to_s.dup.force_encoding(Encoding::BINARY)
-        return payload if payload.empty?
-
-        content_encoding = headers['content-encoding'] || headers[:content_encoding]
-        return payload unless content_encoding.to_s.downcase.include?('gzip') || payload.start_with?("\x1F\x8B".b)
-
-        Zlib::GzipReader.new(StringIO.new(payload)).read
-      rescue Zlib::Error
-        payload
+        JSON.parse(json, symbolize_names: true)
       end
     end
   end

--- a/lib/bigcommerce/request.rb
+++ b/lib/bigcommerce/request.rb
@@ -27,7 +27,7 @@ module Bigcommerce
 
       def delete(path, params = {})
         response = raw_request(:delete, path, params)
-        response.body
+        decode_body(response.body, response.headers)
       end
 
       def post(path, params = {})
@@ -42,7 +42,11 @@ module Bigcommerce
 
       def raw_request(method, path, params = {})
         client = params.delete(:connection) || Bigcommerce.api
-        client.send(method, path.to_s, params)
+        response = client.send(method, path.to_s, params)
+        return response unless response.respond_to?(:body) && response.respond_to?(:body=)
+
+        response.body = decode_body(response.body, response.respond_to?(:headers) ? response.headers : {})
+        response
       end
 
       private

--- a/lib/bigcommerce/version.rb
+++ b/lib/bigcommerce/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bigcommerce
-  VERSION = '1.1.0'
+  VERSION = '2.0.0'
 end

--- a/spec/bigcommerce/bigcommerce_spec.rb
+++ b/spec/bigcommerce/bigcommerce_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Bigcommerce do
       end
 
       it 'should have the correct auth middleware' do
-        expect(middleware).to include(Faraday::Request::BasicAuthentication)
+        expect(middleware).to include(Faraday::Request::Authorization)
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Bigcommerce do
 
       expect(Bigcommerce.api.instance_variable_get('@builder')
                 .instance_variable_get('@handlers'))
-                .to include(Faraday::Request::BasicAuthentication)
+                .to include(Faraday::Request::Authorization)
 
       Bigcommerce.configure do |config|
         config.access_token = 'jksdgkjbhksjdb'

--- a/spec/bigcommerce/bigcommerce_spec.rb
+++ b/spec/bigcommerce/bigcommerce_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe Bigcommerce do
       it 'should have the correct auth middleware' do
         expect(middleware).to include(Faraday::Request::Authorization)
       end
+
+      it 'should include gzip middleware' do
+        expect(middleware.map(&:klass)).to include(Faraday::Gzip::Middleware)
+      end
     end
 
     context 'when not using legacy' do
@@ -41,6 +45,10 @@ RSpec.describe Bigcommerce do
 
       it 'should have the correct auth middleware' do
         expect(middleware).to include(Bigcommerce::Middleware::Auth)
+      end
+
+      it 'should include gzip middleware' do
+        expect(middleware.map(&:klass)).to include(Faraday::Gzip::Middleware)
       end
     end
   end

--- a/spec/bigcommerce/unit/middleware/auth_spec.rb
+++ b/spec/bigcommerce/unit/middleware/auth_spec.rb
@@ -27,5 +27,25 @@ RSpec.describe Bigcommerce::Middleware::Auth do
       expect(app).to receive(:call).with(expected_hash)
       subject
     end
+
+    context 'when options use string keys' do
+      let(:options) do
+        {
+          'client_id' => client_id,
+          'access_token' => client_token
+        }
+      end
+
+      it 'sets the correct headers' do
+        expected_hash = {
+          request_headers: {
+            'X-Auth-Client' => client_id,
+            'X-Auth-Token' => client_token
+          }
+        }
+        expect(app).to receive(:call).with(expected_hash)
+        subject
+      end
+    end
   end
 end

--- a/spec/bigcommerce/unit/request_spec.rb
+++ b/spec/bigcommerce/unit/request_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'stringio'
-require 'zlib'
-
 RSpec.describe Bigcommerce::Request do
   before do
     module Bigcommerce
@@ -20,14 +17,6 @@ RSpec.describe Bigcommerce::Request do
   end
 
   describe 'ClassMethods' do
-    def gzip_payload(payload)
-      io = StringIO.new
-      gz = Zlib::GzipWriter.new(io)
-      gz.write(payload)
-      gz.close
-      io.string
-    end
-
     before do
       double Bigcommerce.api
     end
@@ -47,20 +36,9 @@ RSpec.describe Bigcommerce::Request do
       it 'should call raw_request' do
         response = double
         allow(response).to receive(:body) { '' }
-        allow(response).to receive(:headers) { {} }
         allow(@klass).to receive(:raw_request) { response }
         expect(@klass).to receive(:raw_request).with(:delete, @klass.path, {})
         @klass.delete(@klass.path)
-      end
-
-      it 'decodes gzip encoded response bodies' do
-        payload = '{"ok":true}'
-        response = double
-        allow(response).to receive(:body) { gzip_payload(payload) }
-        allow(response).to receive(:headers) { { 'content-encoding' => 'gzip' } }
-        allow(@klass).to receive(:raw_request).and_return(response)
-
-        expect(@klass.delete(@klass.path)).to eq(payload)
       end
     end
 
@@ -98,29 +76,9 @@ RSpec.describe Bigcommerce::Request do
         expect(@api).to receive(:get).with('path/1', {})
         @klass.raw_request(:get, 'path/1')
       end
-
-      it 'decodes gzip encoded response bodies' do
-        payload = '{"ok":true}'
-        response = Struct.new(:body, :headers).new(
-          gzip_payload(payload),
-          { 'content-encoding' => 'gzip' }
-        )
-        allow(@api).to receive(:get).and_return(response)
-
-        result = @klass.raw_request(:get, 'path/1')
-        expect(result.body).to eq(payload)
-      end
     end
 
     describe 'private methods' do
-      def gzip_payload(payload)
-        io = StringIO.new
-        gz = Zlib::GzipWriter.new(io)
-        gz.write(payload)
-        gz.close
-        io.string
-      end
-
       describe '.build_response_object' do
         before do
           module Bigcommerce
@@ -140,7 +98,6 @@ RSpec.describe Bigcommerce::Request do
           it 'should build an array of objects' do
             response = double
             allow(response).to receive(:body) { json }
-            allow(response).to receive(:headers) { {} }
             objs = @klass_with_init.send(:build_response_object, response)
             expect(objs).to be_kind_of Array
             objs.each do |obj|
@@ -153,19 +110,6 @@ RSpec.describe Bigcommerce::Request do
           it 'should build an object' do
             response = double
             allow(response).to receive(:body) { json }
-            allow(response).to receive(:headers) { {} }
-            objs = @klass_with_init.send(:build_response_object, response)
-            expect(objs).to be_kind_of Bigcommerce::DummyClass
-          end
-        end
-
-        describe 'gzip encoded json object' do
-          let(:json) { "{\"time\":1426184190}" }
-
-          it 'should decode and build an object' do
-            response = double
-            allow(response).to receive(:body) { gzip_payload(json) }
-            allow(response).to receive(:headers) { { 'content-encoding' => 'gzip' } }
             objs = @klass_with_init.send(:build_response_object, response)
             expect(objs).to be_kind_of Bigcommerce::DummyClass
           end

--- a/spec/bigcommerce/unit/request_spec.rb
+++ b/spec/bigcommerce/unit/request_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Bigcommerce::Request do
   end
 
   describe 'ClassMethods' do
+    def gzip_payload(payload)
+      io = StringIO.new
+      gz = Zlib::GzipWriter.new(io)
+      gz.write(payload)
+      gz.close
+      io.string
+    end
+
     before do
       double Bigcommerce.api
     end
@@ -39,9 +47,20 @@ RSpec.describe Bigcommerce::Request do
       it 'should call raw_request' do
         response = double
         allow(response).to receive(:body) { '' }
+        allow(response).to receive(:headers) { {} }
         allow(@klass).to receive(:raw_request) { response }
         expect(@klass).to receive(:raw_request).with(:delete, @klass.path, {})
         @klass.delete(@klass.path)
+      end
+
+      it 'decodes gzip encoded response bodies' do
+        payload = '{"ok":true}'
+        response = double
+        allow(response).to receive(:body) { gzip_payload(payload) }
+        allow(response).to receive(:headers) { { 'content-encoding' => 'gzip' } }
+        allow(@klass).to receive(:raw_request).and_return(response)
+
+        expect(@klass.delete(@klass.path)).to eq(payload)
       end
     end
 
@@ -79,9 +98,29 @@ RSpec.describe Bigcommerce::Request do
         expect(@api).to receive(:get).with('path/1', {})
         @klass.raw_request(:get, 'path/1')
       end
+
+      it 'decodes gzip encoded response bodies' do
+        payload = '{"ok":true}'
+        response = Struct.new(:body, :headers).new(
+          gzip_payload(payload),
+          { 'content-encoding' => 'gzip' }
+        )
+        allow(@api).to receive(:get).and_return(response)
+
+        result = @klass.raw_request(:get, 'path/1')
+        expect(result.body).to eq(payload)
+      end
     end
 
     describe 'private methods' do
+      def gzip_payload(payload)
+        io = StringIO.new
+        gz = Zlib::GzipWriter.new(io)
+        gz.write(payload)
+        gz.close
+        io.string
+      end
+
       describe '.build_response_object' do
         before do
           module Bigcommerce
@@ -122,14 +161,6 @@ RSpec.describe Bigcommerce::Request do
 
         describe 'gzip encoded json object' do
           let(:json) { "{\"time\":1426184190}" }
-
-          def gzip_payload(payload)
-            io = StringIO.new
-            gz = Zlib::GzipWriter.new(io)
-            gz.write(payload)
-            gz.close
-            io.string
-          end
 
           it 'should decode and build an object' do
             response = double

--- a/spec/bigcommerce/unit/request_spec.rb
+++ b/spec/bigcommerce/unit/request_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'stringio'
+require 'zlib'
+
 RSpec.describe Bigcommerce::Request do
   before do
     module Bigcommerce
@@ -98,6 +101,7 @@ RSpec.describe Bigcommerce::Request do
           it 'should build an array of objects' do
             response = double
             allow(response).to receive(:body) { json }
+            allow(response).to receive(:headers) { {} }
             objs = @klass_with_init.send(:build_response_object, response)
             expect(objs).to be_kind_of Array
             objs.each do |obj|
@@ -110,6 +114,27 @@ RSpec.describe Bigcommerce::Request do
           it 'should build an object' do
             response = double
             allow(response).to receive(:body) { json }
+            allow(response).to receive(:headers) { {} }
+            objs = @klass_with_init.send(:build_response_object, response)
+            expect(objs).to be_kind_of Bigcommerce::DummyClass
+          end
+        end
+
+        describe 'gzip encoded json object' do
+          let(:json) { "{\"time\":1426184190}" }
+
+          def gzip_payload(payload)
+            io = StringIO.new
+            gz = Zlib::GzipWriter.new(io)
+            gz.write(payload)
+            gz.close
+            io.string
+          end
+
+          it 'should decode and build an object' do
+            response = double
+            allow(response).to receive(:body) { gzip_payload(json) }
+            allow(response).to receive(:headers) { { 'content-encoding' => 'gzip' } }
             objs = @klass_with_init.send(:build_response_object, response)
             expect(objs).to be_kind_of Bigcommerce::DummyClass
           end


### PR DESCRIPTION
#### What?

- Updated Faraday dependency to version >= 2.14 and removed Faraday Middleware.
- Refactored connection and middleware classes to use the new Faraday request authorization method.
- Adjusted tests to reflect changes in middleware expectations.

#### Tickets / Documentation

- [ANA-6765]

#### Screenshots (if appropriate)

Successfully ran time script: 



```
➜  bigcommerce-api-ruby git:(ANA-6765-upgrade-ruby-3.4-patch-faraday) ✗ bundle exec ruby examples/system/time.rb

#<Bigcommerce::System time=1771450095>
```


[ANA-6765]: https://bigcommercecloud.atlassian.net/browse/ANA-6765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ